### PR TITLE
torii auth against bcnext

### DIFF
--- a/app/controllers/protected.js
+++ b/app/controllers/protected.js
@@ -1,0 +1,5 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+
+});

--- a/app/router.js
+++ b/app/router.js
@@ -9,6 +9,7 @@ Router.map(function() {
   this.route('browsers', function() {
     this.route('browser', {path: ':browser_id'});
   });
+  this.authenticatedRoute('protected');
 });
 
 export default Router;

--- a/app/routes/protected.js
+++ b/app/routes/protected.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+    actions: {
+        signIn: function() {
+            var controller = this.controllerFor('protected');
+            // The provider name is passed to `open`
+            this.get('torii').open('bcnext').then(function(authorization){
+                controller.set('hasAuth', true);
+            });
+        }
+    }
+});

--- a/app/templates/protected.hbs
+++ b/app/templates/protected.hbs
@@ -1,0 +1,8 @@
+{{! app/templates/protected.hbs }}
+{{#if hasAuth}}
+  <strong>Authenticated</strong>
+{{else}}
+  <a href="#" {{action 'signIn'}}>
+    Sign in
+  </a>
+{{/if}}

--- a/app/torii-providers/bcnext.js
+++ b/app/torii-providers/bcnext.js
@@ -1,0 +1,12 @@
+import Oauth2 from 'torii/providers/oauth2-code';
+
+
+var Bcnext = Oauth2.extend({
+    'name': 'bcnext',
+    'baseUrl': 'https://bcnext.herokuapp.com/oauth2/authorize/',
+    'responseParams': ['expires_in', 'state', 'token_type', 'access_token', 'scope'],
+    'responseType': 'token',
+    'redirectUri': 'http://localhost:4200'
+});
+
+export default Bcnext;

--- a/config/environment.js
+++ b/config/environment.js
@@ -19,6 +19,15 @@ module.exports = function(environment) {
     },
     contentSecurityPolicy: {
         'connect-src': "'self' bcnext.herokuapp.com",
+    },
+    torii: {
+        providers: {
+            'bcnext': {
+                apiKey: 'YourClientIdHere',
+                scope: 'read write',
+                redirectUri: 'http://localhost:4200'
+            }
+        }
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.3.0",
     "ember-disable-proxy-controllers": "^1.0.1",
-    "ember-export-application-global": "^1.0.4"
+    "ember-export-application-global": "^1.0.4",
+    "torii": "^0.6.1"
   }
 }

--- a/tests/unit/routes/protected-test.js
+++ b/tests/unit/routes/protected-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:protected', 'Unit | Route | protected', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});


### PR DESCRIPTION
Working but ugly code without overrides:
1. On bcnext, register an application, client type public, auth grant
   type implicit, redirect to http://localhost:4200 (must match bcnext.js)
2. In config/environment.js, add you client ID as the apiKey
3. ember server
4. go to http://localhost:4200/protected
5. click "Sign in"
